### PR TITLE
Use object.assign to support node versions <= 4

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var semver = require("semver");
 var parallel = require("run-parallel");
 var mapValues = require("map-values");
 var filterObject = require("object-filter");
+var assign = require("object.assign");
 
 var PROGRAMS = {
   node: {
@@ -67,7 +68,7 @@ function normalizeWanted(wanted) {
 }
 
 function normalizeOptions(options) {
-  return Object.assign({
+  return assign({
     getVersion: defaultGetVersion,
   }, options);
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "map-values": "^1.0.1",
     "minimist": "^1.2.0",
     "object-filter": "^1.0.2",
+    "object.assign": "^4.0.4",
     "run-parallel": "^1.1.4",
     "semver": "^5.0.3"
   },


### PR DESCRIPTION
`Object.assign` is only supported in node v4 and greater. Running builds on travis with 0.10 and 0.12 fail because of this, which defeats the utility of this tool (to avoid running certain processes in node versions because of lack of support 😋 )