### PR TITLE
Display non-compliant version even if quiet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+## Releases
+
+### 3.0.0
+
+This release changes the default output behavior to only print
+*unsatisfied* versions. If all checked versions pass, there is no
+output. A `--print` option has been added to get the old behavior of
+always printing versions.
+
+* **Breaking**: Remove `--quiet` option, add `--print` option.
+* **Breaking**: Move versions under versions key in result object.
+* Fix bug when version command outputs more than one line.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ OPTIONS
 
 ### Examples
 
-#### Check for `node@6`
+#### Check for node 6, failing
+
+Check for node 6, but have 8.2.1 installed.
 
 ```
 $ check-node-version --node 6
@@ -62,37 +64,43 @@ $ echo $?
 1
 ```
 
-#### Check for `node@4` and `npm@2.14`
-
-```
-$ check-node-version --node 4 --npm 2.14
-node: v0.12.7
-Error: Wanted node version "4" (>=4.0.0 <5.0.0)
-To install node, run `nvm install 4` or check https://nodejs.org/
-$ echo $?
-1
-```
-
-#### Print installed versions
-
-When using the `--print` argument, the current installed versions are
-printed, even if they already matched the requested versions.
-
-```
-$ check-node-version --print
-node: v0.12.7
-npm: v2.14.10
-yarn: v0.21.3
-$ echo $?
-0
-```
-
-#### Check for `node@8` and `npm@5`
+#### Check for node 6, passing
 
 If all versions match, there is no output:
 
 ```
-$ check-node-version --node 8 --npm 5
+$ check-node-version --node 6
+$ echo $?
+0
+```
+
+#### Check for node *and* npm
+
+You can check versions of any combinations of `node`, `npm`, and `yarn`
+at one time.
+
+```
+$ check-node-version --node 4 --npm 2.14
+```
+
+#### Check for `node@4` and `npm@2.14`
+
+You can check for the version of yarn:
+
+```
+$ check-node-version --yarn 0.17.1
+```
+
+#### Print installed versions
+
+Use the `--print` option to print all currently installed versions, even
+if the version checks match.
+
+```
+$ check-node-version --print --node 0.12
+node: v0.12.7
+npm: v2.14.10
+yarn: v0.21.3
 $ echo $?
 0
 ```

--- a/README.md
+++ b/README.md
@@ -42,9 +42,8 @@ OPTIONS
             Use the "engines" key in the current package.json for the
             semver version ranges.
 
-      -q, --quiet
-            Don't output anything. Exit with an error code if a version
-            is not satisfied, otherwise exit with code 0.
+      -p, --print
+            Print installed versions.
 
       -h, --help
             Print this message.
@@ -52,18 +51,15 @@ OPTIONS
 
 ### Examples
 
-#### Get installed versions
-
-When no versions are given, the current node, npm, and yarn versions are
-printed out.
+#### Check for `node@6`
 
 ```
-$ check-node-version
-node: v0.12.7
-npm: v2.14.10
-yarn: v0.21.3
+$ check-node-version --node 6
+node: 8.2.1
+Error: Wanted node version 6 (>=6.0.0 <7.0.0)
+To install node, run `nvm install 6` or see https://nodejs.org/
 $ echo $?
-0
+1
 ```
 
 #### Check for `node@4` and `npm@2.14`
@@ -71,25 +67,34 @@ $ echo $?
 ```
 $ check-node-version --node 4 --npm 2.14
 node: v0.12.7
-npm: v2.14.10
-yarn: v0.21.3
 Error: Wanted node version "4" (>=4.0.0 <5.0.0)
 To install node, run `nvm install 4` or check https://nodejs.org/
 $ echo $?
 1
 ```
 
-#### Check for `node@4` and `npm@2.14`, `yarn` not installed
+#### Print installed versions
+
+When using the `--print` argument, the current installed versions are
+printed, even if they already matched the requested versions.
 
 ```
-$ check-node-version --node 4 --npm 2.14
+$ check-node-version --print
 node: v0.12.7
 npm: v2.14.10
-yarn: not installed
-Error: Wanted node version "4" (>=4.0.0 <5.0.0)
-To install node, run `nvm install 4` or check https://nodejs.org/
+yarn: v0.21.3
 $ echo $?
-1
+0
+```
+
+#### Check for `node@8` and `npm@5`
+
+If all versions match, there is no output:
+
+```
+$ check-node-version --node 8 --npm 5
+$ echo $?
+0
 ```
 
 #### Use with a `.nvmrc` file

--- a/bin.js
+++ b/bin.js
@@ -19,20 +19,22 @@ function logVersionError(name, err) {
   }
 }
 
-function logResult(result) {
-  // report installed versions
-  Object.keys(PROGRAMS).forEach(function(name) {
-    var info = result[name];
-    if (info.version) {
-      console.log(name + ": " + info.version);
-    }
-    if (info.notfound) {
-      console.error(name + ': not installed');
-    }
-    if (info.error) {
-      logVersionError(name, info.error);
-    }
-  });
+function logResult(result, quiet) {
+  if (!quiet) {
+    // report installed versions
+    Object.keys(PROGRAMS).forEach(function(name) {
+      var info = result[name];
+      if (info.version) {
+        console.log(name + ": " + info.version);
+      }
+      if (info.notfound) {
+        console.error(name + ': not installed');
+      }
+      if (info.error) {
+        logVersionError(name, info.error);
+      }
+    });
+  }
 
   // display any non-compliant versions
   Object.keys(PROGRAMS).forEach(function(name) {
@@ -94,8 +96,6 @@ check(options, function(err, result) {
     process.exit(1);
     return;
   }
-  if ( ! argv.quiet) {
-    logResult(result);
-  }
+  logResult(result, argv.quiet);
   process.exit(result.isSatisfied ? 0 : 1);
 });

--- a/bin.js
+++ b/bin.js
@@ -19,26 +19,27 @@ function logVersionError(name, err) {
   }
 }
 
-function logResult(result, quiet) {
-  if (!quiet) {
-    // report installed versions
-    Object.keys(PROGRAMS).forEach(function(name) {
-      var info = result[name];
-      if (info.version) {
-        console.log(name + ": " + info.version);
-      }
-      if (info.notfound) {
-        console.error(name + ': not installed');
-      }
-      if (info.error) {
-        logVersionError(name, info.error);
-      }
-    });
+function printInstalledVersion(name, info) {
+  if (info.version) {
+    console.log(name + ": " + info.version);
   }
+  if (info.notfound) {
+    console.error(name + ': not installed');
+  }
+  if (info.error) {
+    logVersionError(name, info.error);
+  }
+}
 
-  // display any non-compliant versions
+function printInvalidVersions(result, print) {
   Object.keys(PROGRAMS).forEach(function(name) {
-    if (result[name].isSatisfied === false) {
+    const isSatisfied = result[name].isSatisfied !== false;
+    // report installed version
+    if (print || !isSatisfied) {
+      printInstalledVersion(name, result[name]);
+    }
+    // display any non-compliant versions
+    if (!isSatisfied) {
       var raw = result[name].wanted.raw;
       var range = result[name].wanted.range;
       console.log("Error: Wanted " + name + " version " + raw + " (" + range +")");
@@ -49,11 +50,11 @@ function logResult(result, quiet) {
 
 var argv = minimist(process.argv.slice(2), {
   alias: {
-    "quiet": "q",
+    "print": "p",
     "help": "h",
   },
   boolean: [
-    "quiet",
+    "print",
     "help",
   ],
 });
@@ -96,6 +97,6 @@ check(options, function(err, result) {
     process.exit(1);
     return;
   }
-  logResult(result, argv.quiet);
+  printInvalidVersions(result, argv.print);
   process.exit(result.isSatisfied ? 0 : 1);
 });

--- a/bin.js
+++ b/bin.js
@@ -31,17 +31,18 @@ function printInstalledVersion(name, info) {
   }
 }
 
-function printInvalidVersions(result, print) {
+function printVersions(result, print) {
   Object.keys(PROGRAMS).forEach(function(name) {
-    const isSatisfied = result[name].isSatisfied !== false;
+    var info = result.versions[name];
+    var isSatisfied = info.isSatisfied;
     // report installed version
     if (print || !isSatisfied) {
-      printInstalledVersion(name, result[name]);
+      printInstalledVersion(name, info);
     }
     // display any non-compliant versions
     if (!isSatisfied) {
-      var raw = result[name].wanted.raw;
-      var range = result[name].wanted.range;
+      var raw = info.wanted.raw;
+      var range = info.wanted.range;
       console.log("Error: Wanted " + name + " version " + raw + " (" + range +")");
       console.log(PROGRAMS[name].getInstallInstructions(raw));
     }
@@ -97,6 +98,6 @@ check(options, function(err, result) {
     process.exit(1);
     return;
   }
-  printInvalidVersions(result, argv.print);
+  printVersions(result, argv.print);
   process.exit(result.isSatisfied ? 0 : 1);
 });

--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ function runVersionCommand(command, callback) {
     }
     else {
       return callback(null, {
-        version: stdin.toString().trim(),
+        version: stdin.toString().split('\n')[0].trim(),
       });
     }
   });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "check-node-version",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "Check installed versions of node and npm",
   "main": "index.js",
   "bin": {

--- a/test.js
+++ b/test.js
@@ -25,11 +25,11 @@ function getMockedGetVersionsOptions(versions) {
 test("simple call", function(t) {
   check(function(err, result) {
     t.ifError(err);
-    t.ok(result.node);
-    t.ok(result.node.version);
-    t.ok(result.npm);
-    t.ok(result.npm.version);
-    t.ok(result.yarn);
+    t.ok(result.versions.node);
+    t.ok(result.versions.node.version);
+    t.ok(result.versions.npm);
+    t.ok(result.versions.npm.version);
+    t.ok(result.versions.yarn);
     t.ok(result.isSatisfied);
     t.end();
   });
@@ -45,11 +45,11 @@ test("positive node result", function(t) {
   });
   check(wanted, options, function(err, result) {
     t.ifError(err);
-    t.ok(result.node);
-    t.ok(result.node.version);
-    t.equal(result.node.version.raw, version);
-    t.equal(result.node.wanted.range, version);
-    t.equal(result.node.isSatisfied, true);
+    t.ok(result.versions.node);
+    t.ok(result.versions.node.version);
+    t.equal(result.versions.node.version.raw, version);
+    t.equal(result.versions.node.wanted.range, version);
+    t.equal(result.versions.node.isSatisfied, true);
     t.equal(result.isSatisfied, true);
     t.end();
   });
@@ -65,10 +65,10 @@ test("negative node result", function(t) {
   });
   check(wanted, options, function(err, result) {
     t.ifError(err);
-    t.ok(result.node);
-    t.equal(result.node.version.raw, version);
-    t.equal(result.node.wanted.range, "6.9.9");
-    t.equal(result.node.isSatisfied, false);
+    t.ok(result.versions.node);
+    t.equal(result.versions.node.version.raw, version);
+    t.equal(result.versions.node.wanted.range, "6.9.9");
+    t.equal(result.versions.node.isSatisfied, false);
     t.equal(result.isSatisfied, false);
     t.end();
   });
@@ -85,13 +85,13 @@ test("positive node result, yarn not installed", function(t) {
   });
   check(wanted, options, function(err, result) {
     t.ifError(err);
-    t.ok(result.node);
-    t.equal(result.node.version.raw, version);
-    t.equal(result.node.wanted.range, version);
-    t.equal(result.node.isSatisfied, true);
+    t.ok(result.versions.node);
+    t.equal(result.versions.node.version.raw, version);
+    t.equal(result.versions.node.wanted.range, version);
+    t.equal(result.versions.node.isSatisfied, true);
     t.equal(result.isSatisfied, true);
-    t.equal(result.yarn.version, undefined);
-    t.ok(result.yarn.error);
+    t.equal(result.versions.yarn.version, undefined);
+    t.ok(result.versions.yarn.error);
     t.end();
   });
 });
@@ -107,12 +107,12 @@ test("negative node result, yarn not installed", function(t) {
   });
   check(wanted, options, function(err, result) {
     t.ifError(err);
-    t.ok(result.node);
-    t.equal(result.node.version.raw, "7.0.0");
-    t.equal(result.node.wanted.range, "6.9.9");
-    t.equal(result.node.isSatisfied, false);
-    t.equal(result.yarn.version, undefined);
-    t.ok(result.yarn.error);
+    t.ok(result.versions.node);
+    t.equal(result.versions.node.version.raw, "7.0.0");
+    t.equal(result.versions.node.wanted.range, "6.9.9");
+    t.equal(result.versions.node.isSatisfied, false);
+    t.equal(result.versions.yarn.version, undefined);
+    t.ok(result.versions.yarn.error);
     t.equal(result.isSatisfied, false);
     t.end();
   });
@@ -129,8 +129,8 @@ test("negative yarn result, yarn not installed", function(t) {
   });
   check(wanted, options, function(err, result) {
     t.ifError(err);
-    t.equal(result.yarn.version, undefined);
-    t.equal(result.yarn.wanted.range, "1.1.1");
+    t.equal(result.versions.yarn.version, undefined);
+    t.equal(result.versions.yarn.wanted.range, "1.1.1");
     t.equal(result.isSatisfied, false);
     t.end();
   });

--- a/usage.txt
+++ b/usage.txt
@@ -18,9 +18,8 @@ Options:
             Use the "engines" key in the current package.json for the
             semver version ranges.
 
-      -q, --quiet
-            Don't output anything. Exit with an error code if a version
-            is not satisfied, otherwise exit with code 0.
+      -p, --print
+            Print installed versions.
 
       -h, --help
             Print this message.


### PR DESCRIPTION
Hey,

A small PR to display non-compliant versions / install instructions even if the `quiet` flag is present.

`quiet` should remove all informative output but still keep the output related to this package main goal: check for engines version. In my use case, I have several `pre` scripts that need a check. I don't want a verbose output each time I roll a run-script, however, I do want to warn about non-compliant engines and instruct the user about it.

Some follow up on this:
 - If you still want to maintain the current behavior, a `--silent` flag could just silence everything.
 - But IMHO I would not display engine versions by default as it's not what this package is made for. I would instead propose an opt-in for that behind a `--print` flag.

Cheers