### PR TITLE
Don't treat presence of stderr as error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Releases
 
+### 3.1.1
+
+* Fix bug with npm warnings causing errors.
+
 ### 3.1.0
 
 * Add colors to terminal output.

--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ function runVersionCommand(command, callback) {
         notfound: true,
       });
     }
-    else if (execError || stderr) {
+    else if (execError) {
       var runError = new Error("Command failed: " + commandDescription);
       if (stderr) {
         runError.stderr = stderr.trim();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "check-node-version",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Check installed versions of node and npm",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
For example, npm will log warnings to stderr even when the version command succeeds and prints the version to stdout.

This fixes an issue being observed in CI tests in Appveyor when using node 4 -- npm prints warnings to stderr.