### PR TITLE
Adopt Github-enabled license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <http://unlicense.org>

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "semver"
   ],
   "author": "Parsha Pourkhomami",
-  "license": "WTFPL",
+  "license": "Unlicense",
   "types": "./index.d.ts",
   "bugs": {
     "url": "https://github.com/parshap/check-node-version/issues"


### PR DESCRIPTION
Hi there,
In my current project, I need to check the license of each package I add. Unfortunately, this project does not contain a LICENSE file. Personally, I'm cool with that, but coporate Jim™ really loves his license files.

Additionally, I suggest the Unlicense because it is almost functionally identical to the WTFPL, while at the same time enabling Github's neat license info.

It would be awesome if you were to accept this. I could then include this package and help out with issue fixes. I'm positive that I can resolve at least some of the existing issues.

Cheers! 🙂