### PR TITLE
Add support for Volta

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,15 @@ at one time.
 $ check-node-version --node 4 --npm 2.14 --npx 6 --yarn 0.17.1
 ```
 
+<a name="check-node-version-command-line-usage-examples-check-for-volta-pinned-versions"></a>
+#### Check for volta pinned versions
+
+You can check versions pinned by [Volta](https://volta.sh/):
+
+```bash
+$ check-node-version --volta
+```
+
 <a name="check-node-version-command-line-usage-examples-print-installed-versions"></a>
 #### Print installed versions
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <a name="check-node-version"></a>
 # check-node-version
 [![NPM version](http://img.shields.io/npm/v/check-node-version.svg?style=flat-square)](https://www.npmjs.org/package/check-node-version)
-[![AppVeyor build status](https://img.shields.io/appveyor/ci/samsaggace/check-node-version/master.svg?style=flat-square)](https://ci.appveyor.com/project/samsaggace/check-node-version/branch/master)
-[![Travis build status](http://img.shields.io/travis/samsaggace/check-node-version/master.svg?style=flat-square)](https://travis-ci.org/samsaggace/check-node-version)
+[![AppVeyor build status](https://img.shields.io/appveyor/ci/parshap/check-node-version/master.svg?style=flat-square)](https://ci.appveyor.com/project/parshap/check-node-version/branch/master)
+[![Travis build status](http://img.shields.io/travis/parshap/check-node-version/master.svg?style=flat-square)](https://travis-ci.org/samsaggace/check-node-version)
 
 Check installed versions of `node`, `npm`, `npx`, and `yarn`.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <a name="check-node-version"></a>
 # check-node-version
 [![NPM version](http://img.shields.io/npm/v/check-node-version.svg?style=flat-square)](https://www.npmjs.org/package/check-node-version)
-[![AppVeyor build status](https://img.shields.io/appveyor/ci/parshap/check-node-version/master.svg?style=flat-square)](https://ci.appveyor.com/project/parshap/check-node-version/branch/master)
-[![Travis build status](http://img.shields.io/travis/parshap/check-node-version/master.svg?style=flat-square)](https://travis-ci.org/parshap/check-node-version)
+[![AppVeyor build status](https://img.shields.io/appveyor/ci/samsaggace/check-node-version/master.svg?style=flat-square)](https://ci.appveyor.com/project/samsaggace/check-node-version/branch/master)
+[![Travis build status](http://img.shields.io/travis/samsaggace/check-node-version/master.svg?style=flat-square)](https://travis-ci.org/samsaggace/check-node-version)
 
 Check installed versions of `node`, `npm`, `npx`, and `yarn`.
 
@@ -58,6 +58,9 @@ OPTIONS
       --package
             Use the "engines" key in the current package.json for the
             semver version ranges.
+      
+      --volta
+            Use the versions pinned by Volta in the package.json
 
       -p, --print
             Print installed versions.

--- a/README_src.md
+++ b/README_src.md
@@ -55,6 +55,14 @@ at one time.
 $ check-node-version --node 4 --npm 2.14 --npx 6 --yarn 0.17.1
 ```
 
+#### Check for volta pinned versions
+
+You can check versions pinned by [Volta](https://volta.sh/):
+
+```bash
+$ check-node-version --volta
+```
+
 #### Print installed versions
 
 Use the `--print` option to print currently installed versions.

--- a/usage.txt
+++ b/usage.txt
@@ -30,6 +30,9 @@ OPTIONS
       --package
             Use the "engines" key in the current package.json for the
             semver version ranges.
+      
+      --volta
+            Use the versions pinned by Volta in the package.json
 
       -p, --print
             Print installed versions.


### PR DESCRIPTION
- Add --volta option to cli
- Parse volta key in package.json
- Add documentation in usage.txt and README
- Return error when using unsupported option (was really helpful to me
when trying to debug a typo)

Solves https://github.com/parshap/check-node-version/issues/47