### PR TITLE
Attach null stdio to pass nvm-windows check

### DIFF
--- a/tools.js
+++ b/tools.js
@@ -42,7 +42,7 @@ function hasNvm() {
    // check for existance of nvm
    execSync(
      'nvm',
-     { stdio:[] } // don't care about output
+     { stdio: 'ignore' } // don't care about output
    );
   } catch (e) {
    // no nvm,


### PR DESCRIPTION
https://github.com/coreybutler/nvm-windows/blob/6284f0ec44040764dc269144a3433664bf089646/src/nvm.go#L188
https://github.com/coreybutler/nvm-windows/blob/6284f0ec44040764dc269144a3433664bf089646/src/nvm.go#L73

In nvm-windows, if stdout isn't a character device, it shows an error dialog and waits for user input before terminating

Attach /dev/null to make sure that nvm-windows doesn't need intervention (https://nodejs.org/api/child_process.html#optionsstdio)